### PR TITLE
Enhance hover values with clickable replacement links

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,11 @@
         "@types/node": "18.8.2",
         "@types/vscode": "^1.71.0",
         "typescript": "^4.8.4"
-    }
+    },
+    "commands": [
+        {
+            "command": "hexHover.replace",
+            "title": "Replace hovered value"
+        }
+    ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
 
-let lastHoverRange: vscode.Range | undefined; // Stores the range currently hovered
-let lastHoverDocument: vscode.Uri | undefined; // Stores which document contains the hover
+// Stores the range currently hovered
+let lastHoverRange: vscode.Range = new vscode.Range(new vscode.Position(0,0), new vscode.Position(0,0));
+// Stores which document contains the hover
+let lastHoverDocument: vscode.Uri | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
     const hoverProvider = vscode.languages.registerHoverProvider({scheme: '*', language: '*'}, {
@@ -139,7 +141,7 @@ export function activate(context: vscode.ExtensionContext) {
                 }
                 // Check that the editor can be edited and that a range is selected
                 const editor = vscode.window.activeTextEditor;
-                if (!editor || !lastHoverRange || !lastHoverDocument) {
+                if (!editor || !lastHoverDocument || lastHoverRange.isEmpty) {
                     return;
                 }
                 // Check that the current editor is the same as the one where the hover is
@@ -152,7 +154,9 @@ export function activate(context: vscode.ExtensionContext) {
                 });
                 // Close the hover
                 await vscode.commands.executeCommand('editor.action.hideHover');
-                lastHoverRange = undefined;
+                // Reset the range
+                lastHoverRange.start.with(0,0);
+                lastHoverRange.end.with(0,0);
                 lastHoverDocument = undefined;
             }
         )


### PR DESCRIPTION
## Description:
This PR makes numeric values in hovers clickable. Clicking a value replaces the currently hovered number in the editor with the chosen representation.

### Highlights
- Cells of the markdown table are now interactive links.
- Clicking a value updates the hovered text.
- Hover closes automatically after replacement.

### Benefits
Users can quickly replace numeric literals with different representations directly from the hover.

### Key changes:
- Implemented a "hexHover.replace" command to replace the hovered text.
- Added a makeReplaceLink helper to generate create markdown links able to trigger a command
- Updated addColumn to display hover table cells as clickable links.
